### PR TITLE
Deploy update to the same pr in sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - DEBUG="pr-apps*"
     - DEBUG_COLORS=yes
     - FAIL_FAST=1
-    - RETRY_TIMEOUT=90000
+    - COVERAGE=1
     - SLEEP_BETWEEN_TESTS=5000
     - SLOW_DOWN_DEPLOY=1
     - TEST_GH_REPO=https://github.com/featurist/pr-apps-test-repo.git
@@ -16,4 +16,7 @@ before_script:
   - yarn sequelize db:create
 cache: yarn
 script:
-  - ./test
+  - "./node_modules/.bin/standard $(git ls-files | grep -e '.js$')"
+  - ./test-memory
+  - ./test-local
+  - "RETRY_TIMEOUT=90000 ./test-real --tags @ci"

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ./scripts/downloadAppInfo.sh && node index.js
+web: ./scripts/downloadAppInfo.sh && DEBUG=pr-apps* node index.js

--- a/features/configureApp.feature
+++ b/features/configureApp.feature
@@ -1,5 +1,6 @@
 Feature: Configure Pr App environment, resources, routes, etc.
 
+  @ci
   Scenario: Add environment variables to new pr app
     Given Frank's app needs environment variables "FOO=bar" and "STUFF=1"
     When Frank adds configuration file specifying extra environment

--- a/features/deployPullRequest.feature
+++ b/features/deployPullRequest.feature
@@ -1,25 +1,30 @@
 Feature: Deploy Github pull request
 
+  @ci
   Scenario: User opens new pull request
     Given Frank pushed a branch to a code hosting service
     When Frank opens a pull request for that branch
     Then Frank should see that deploy of a pr app has started
 
+  @ci
   Scenario: Pr author is notified when deploy of the new app is complete
     Given the deploy of Frank's new pr app has started
     When the deploy is complete
     Then Frank sees that the deploy is complete
 
+  @ci
   Scenario: Pr author visits new app
     Given Frank received a notification that his pr app deploy is complete
     When Frank follows the link in the notifiation
     Then Frank sees the new app
 
+  @ci
   Scenario: User pushes changes to existing pull request
     Given Frank has a pr app
     When Frank pushes changes to the pr branch
     Then Frank should see that deploy of a pr app has started
 
+  @ci
   Scenario: Pr author is notified when update is deployed
     Given the deploy of the update of Frank's pr app has started
     When the deploy is complete
@@ -30,11 +35,13 @@ Feature: Deploy Github pull request
     When Frank follows the link in the notifiation
     Then Frank sees the updated app
 
+  @ci
   Scenario: User reopens pull request
     Given Frank has a closed pull request
     When Frank reopens that pull request
     Then Frank should see that deploy of a pr app has started
 
+  @ci
   Scenario: Pr author is notified when deploy has failed
     Given the deploy of Frank's broken pr app has started
     When the deploy fails

--- a/features/deployPullRequest.feature
+++ b/features/deployPullRequest.feature
@@ -39,3 +39,8 @@ Feature: Deploy Github pull request
     Given the deploy of Frank's broken pr app has started
     When the deploy fails
     Then Frank sees that the deploy failed
+
+  Scenario: User pushes more changes while a deploy is in progress
+    Given a deploy of Frank's pr app has started
+    When Frank pushes changes to the pr branch while deploy is still in progress
+    Then Frank's new deploy does not start until the current one is complete

--- a/features/deployPullRequest.feature
+++ b/features/deployPullRequest.feature
@@ -47,6 +47,7 @@ Feature: Deploy Github pull request
     When the deploy fails
     Then Frank sees that the deploy failed
 
+  @ci
   Scenario: User pushes more changes while a deploy is in progress
     Given a deploy of Frank's pr app has started
     When Frank pushes changes to the pr branch while deploy is still in progress

--- a/features/destroyApp.feature
+++ b/features/destroyApp.feature
@@ -1,3 +1,4 @@
+@ci
 Feature: Automatically destroy Pr App
 
   Scenario: User merges pull request

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -6,35 +6,35 @@ Given('{actor} pushed a branch to a code hosting service', async function (actor
 })
 
 When('{actor} opens a pull request for that branch', async function (actor) {
-  await actor.openPullRequest()
+  this.prNotifier = await actor.openPullRequest()
 })
 
 Then('{actor} should see that deploy of a pr app has started', async function (actor) {
-  await actor.shouldSeeDeployStarted()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
 })
 
 Given('the deploy of {actor}\'s new pr app has started', async function (actor) {
   await this.assembly.enablePrEvents()
   await actor.pushBranch()
-  await actor.openPullRequest()
-  await actor.shouldSeeDeployStarted()
+  this.prNotifier = await actor.openPullRequest()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
   this.currentActor = actor
 })
 
 When('the deploy is complete', async function () {
-  await this.currentActor.shouldSeeDeployFinished()
+  await this.currentActor.shouldSeeDeployFinished(this.prNotifier)
 })
 
 Then('{actor} sees that the deploy is complete', async function (actor) {
-  await actor.shouldSeeDeploySuccessful()
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
 })
 
 Given('{actor} received a notification that his pr app deploy is complete', async function (actor) {
   await this.assembly.enablePrEvents()
   await actor.pushBranch()
-  await actor.openPullRequest()
-  await actor.shouldSeeDeployStarted()
-  await actor.shouldSeeDeploySuccessful()
+  this.prNotifier = await actor.openPullRequest()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
 })
 
 When('{actor} follows the link in the notifiation', async function (actor) {
@@ -54,16 +54,16 @@ Given('{actor} has a pr app', async function (actor) {
 })
 
 When('{actor} pushes changes to the pr branch', async function (actor) {
-  await actor.pushMoreChanges()
-  await actor.shouldSeeDeployStarted()
+  this.prNotifier = await actor.pushMoreChanges()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
 })
 
 Given('the deploy of the update of {actor}\'s pr app has started', async function (actor) {
   await actor.withExistingPrApp()
   await this.assembly.enablePrEvents()
 
-  await actor.pushMoreChanges()
-  await actor.shouldSeeDeployStarted()
+  this.prNotifier = await actor.pushMoreChanges()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
   this.currentActor = actor
 })
 
@@ -71,9 +71,9 @@ Given('{actor} received a notification that his app is updated', async function 
   await actor.withExistingPrApp()
   await this.assembly.enablePrEvents()
 
-  await actor.pushMoreChanges()
-  await actor.shouldSeeDeployStarted()
-  await actor.shouldSeeDeploySuccessful()
+  this.prNotifier = await actor.pushMoreChanges()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
 })
 
 Then('{actor} sees the updated app', async function (actor) {
@@ -98,34 +98,34 @@ Given('{actor} has a closed pull request', async function (actor) {
 })
 
 When('{actor} reopens that pull request', async function (actor) {
-  await actor.reopenPullRequest()
+  this.prNotifier = await actor.reopenPullRequest()
 })
 
 Given('the deploy of {actor}\'s broken pr app has started', async function (actor) {
   this.assembly.fakeFlynnApi.failNextDeploy()
   await this.assembly.enablePrEvents()
   await actor.pushBranch()
-  await actor.openPullRequest()
-  await actor.shouldSeeDeployStarted()
+  this.prNotifier = await actor.openPullRequest()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
   this.currentActor = actor
 })
 
 When('the deploy fails', async function () {
-  await this.currentActor.shouldSeeDeployFinished()
+  await this.currentActor.shouldSeeDeployFinished(this.prNotifier)
 })
 
 Then('{actor} sees that the deploy failed', async function (actor) {
-  await actor.shouldSeeDeployFailed()
+  await actor.shouldSeeDeployFailed(this.prNotifier)
   await actor.shouldNotSeeApp()
 })
 
 Then('{actor} sees that the deploy failed instantly', async function (actor) {
-  await actor.shouldSeeDeployFailed({instantly: true})
+  await actor.shouldSeeDeployFailed(this.prNotifier, {instantly: true})
   await actor.shouldNotSeeApp()
 })
 
 Then('{actor} can see the validation error', async function (actor) {
-  const logPage = await actor.followLastDeploymentUrl()
+  const logPage = await actor.followLastDeploymentUrl({prNotifier: this.prNotifier})
   actor.shouldSeeValidationError(logPage)
 })
 
@@ -144,11 +144,11 @@ env:
 When('{actor} opens a new pull request', async function (actor) {
   await this.assembly.enablePrEvents()
   await actor.pushBranch()
-  await actor.openPullRequest()
+  this.prNotifier = await actor.openPullRequest()
 })
 
 Then('{actor}\'s pr app has those environment variables set', async function (actor) {
-  await actor.shouldSeeDeploySuccessful()
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
   await actor.assertEnvironmentSet(this.envVars.reduce((result, [key, value]) => {
     result[key] = value
     return result
@@ -201,7 +201,7 @@ resources:
 
 Then('{actor}\'s pr app has postgres and redis', async function (actor) {
   await Promise.all([
-    actor.shouldSeeDeploySuccessful(),
+    actor.shouldSeeDeploySuccessful(this.prNotifier),
     actor.assertEnvironmentSet({
       FOO: 'bar',
       REDIS_URL: 'redis://stuff',
@@ -244,31 +244,31 @@ resources:
 Given('{actor} opened a pull request', async function (actor) {
   await this.assembly.enablePrEvents()
   this.scmVersion = await actor.pushBranch()
-  await actor.openPullRequest()
-  await actor.shouldSeeDeploySuccessful()
+  this.prNotifier = await actor.openPullRequest()
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
 })
 
 Given('{actor} updated his pull request', async function (actor) {
   await actor.withExistingPrApp()
   await this.assembly.enablePrEvents()
-  await actor.pushMoreChanges()
-  await actor.shouldSeeDeploySuccessful()
+  this.prNotifier = await actor.pushMoreChanges()
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
 })
 
 Given('{actor} has pushed a broken change', async function (actor) {
   await actor.withExistingPrApp()
   this.assembly.fakeFlynnApi.failNextDeploy()
   await this.assembly.enablePrEvents()
-  await actor.pushMoreChanges()
-  await actor.shouldSeeDeployFailed()
+  this.prNotifier = await actor.pushMoreChanges()
+  await actor.shouldSeeDeployFailed(this.prNotifier)
 })
 
 Given('the deployment of {actor}\'s pr apps has failed', async function (actor) {
   await actor.withExistingPrApp()
   this.assembly.fakeFlynnApi.failNextDeploy()
   await this.assembly.enablePrEvents()
-  await actor.pushMoreChanges()
-  await actor.shouldSeeDeployFailed()
+  this.prNotifier = await actor.pushMoreChanges()
+  await actor.shouldSeeDeployFailed(this.prNotifier)
 })
 
 Given('{actor} has a pr app with an environment variable {envVar} and {envVar}', async function (actor, envVar, envVar2) {
@@ -289,7 +289,7 @@ env:
 })
 
 Then('{actor}\'s app environment should change to {envVar}, {envVar} and keep {envVar}', async function (actor, envVar, envVar2, envVar3) {
-  await actor.shouldSeeDeploySuccessful()
+  await actor.shouldSeeDeploySuccessful(this.prNotifier)
   await actor.assertEnvironmentSet([envVar, envVar2, envVar3].reduce((result, [key, value]) => {
     result[key] = value
     return result
@@ -297,7 +297,7 @@ Then('{actor}\'s app environment should change to {envVar}, {envVar} and keep {e
 })
 
 When('{actor} follows a deployment link from the last deploy', async function (actor) {
-  this.logPage = await actor.followLastDeploymentUrl()
+  this.logPage = await actor.followLastDeploymentUrl({prNotifier: this.prNotifier})
 })
 
 Then('{actor} sees details of that deployment', function (actor) {
@@ -312,45 +312,45 @@ Given('{actor} opened two pull requests', async function (actor) {
   await this.assembly.enablePrEvents()
 
   await actor.pushBranch()
-  this.pr1Number = await actor.openPullRequest()
-  await actor.shouldSeeDeploySuccessful()
+  let prNotifier = await actor.openPullRequest({prNumber: 23})
+  await actor.shouldSeeDeploySuccessful(prNotifier)
 
-  this.deployLogUrl1 = actor.getLastDeploymentUrl()
+  this.deployLogUrl1 = actor.getLastDeploymentUrl(prNotifier)
   actor.shouldSeeDeployLogs(
-    await actor.followLastDeploymentUrl(this.deployLogUrl1)
+    await actor.followLastDeploymentUrl({url: this.deployLogUrl1})
   )
 
   await actor.pushBranch('Feature2')
-  await actor.openPullRequest({prNumber: 24, branch: 'Feature2'})
-  await actor.shouldSeeDeploySuccessful()
+  prNotifier = await actor.openPullRequest({prNumber: 24, branch: 'Feature2'})
+  await actor.shouldSeeDeploySuccessful(prNotifier)
 
-  this.deployLogUrl2 = actor.getLastDeploymentUrl()
+  this.deployLogUrl2 = actor.getLastDeploymentUrl(prNotifier)
   actor.shouldSeeDeployLogs(
-    await actor.followLastDeploymentUrl(this.deployLogUrl2)
+    await actor.followLastDeploymentUrl({url: this.deployLogUrl2})
   )
 })
 
 When('{actor} closes one of them', async function (actor) {
-  await actor.mergePullRequest(this.pr1Number)
-  await actor.shouldNotSeeApp(`pr-${this.pr1Number}`)
+  await actor.mergePullRequest(23)
+  await actor.shouldNotSeeApp('pr-23')
 })
 
 Then('{actor} can only see deploy logs of the other one', async function (actor) {
   await actor.shouldNotSeeDeployLogs(this.deployLogUrl1)
   actor.shouldSeeDeployLogs(
-    await actor.followLastDeploymentUrl(this.deployLogUrl2)
+    await actor.followLastDeploymentUrl({url: this.deployLogUrl2})
   )
 })
 
 When('{actor} decides to redeploy it', async function (actor) {
-  this.logPage = await actor.followLastDeploymentUrl()
+  this.logPage = await actor.followLastDeploymentUrl({prNotifier: this.prNotifier})
   this.prevDeploymentId = actor.lookUpDeploymentId(this.logPage)
   await actor.redeploy(this.logPage)
 })
 
 Then('{actor} sees the new deployment page', async function (actor) {
   await actor.shouldSeeNewDeploymentDetails({
-    logPage: this.logPage,
+    prNotifier: this.prNotifier,
     prevDeploymentId: this.prevDeploymentId
   })
 })
@@ -358,10 +358,24 @@ Then('{actor} sees the new deployment page', async function (actor) {
 Given('the deployment of {actor}\'s PR is in progress', async function (actor) {
   await this.assembly.enablePrEvents()
   await actor.pushBranch()
-  await actor.openPullRequest()
-  await actor.shouldSeeDeployStarted()
+  this.prNotifier = await actor.openPullRequest()
+  await actor.shouldSeeDeployStarted(this.prNotifier)
 })
 
 Then('{actor} can not start another deploy', async function (actor) {
   await actor.shouldNotBeAbleToRedeploy(this.logPage)
+})
+
+Then('{actor}\'s new deploy does not start until the current one is complete', async function (actor) {
+  await actor.shouldSeeOneDeployAfterAnother(this.prNotifier)
+})
+
+Given('a deploy of {actor}\'s pr app has started', async function (actor) {
+  await this.assembly.enablePrEvents()
+  await actor.pushBranch()
+  this.prNotifier = await actor.openPullRequest()
+})
+
+When('{actor} pushes changes to the pr branch while deploy is still in progress', async function (actor) {
+  await actor.pushMoreChanges()
 })

--- a/features/step_definitions/steps.js
+++ b/features/step_definitions/steps.js
@@ -377,5 +377,5 @@ Given('a deploy of {actor}\'s pr app has started', async function (actor) {
 })
 
 When('{actor} pushes changes to the pr branch while deploy is still in progress', async function (actor) {
-  await actor.pushMoreChanges()
+  this.prNotifier = await actor.pushMoreChanges()
 })

--- a/features/support/assemblies/github/githubService.js
+++ b/features/support/assemblies/github/githubService.js
@@ -2,9 +2,9 @@ const PrNotifier = require('../memory/prNotifier')
 const debug = require('debug')('pr-apps:test:githubService')
 
 module.exports = class GithubService {
-  constructor ({prEventsListener, ghApi, fakeFlynnApi}) {
+  constructor ({deploymentStatusEvents, ghApi, fakeFlynnApi}) {
     this.ghApi = ghApi
-    this.prEventsListener = prEventsListener
+    this.deploymentStatusEvents = deploymentStatusEvents
     this.fakeFlynnApi = fakeFlynnApi
   }
 
@@ -110,7 +110,7 @@ module.exports = class GithubService {
 
   newPrNotifier (branch) {
     return new PrNotifier({
-      prEventsListener: this.prEventsListener,
+      deploymentStatusEvents: this.deploymentStatusEvents,
       fakeFlynnApi: this.fakeFlynnApi,
       branch
     })

--- a/features/support/assemblies/github/githubService.js
+++ b/features/support/assemblies/github/githubService.js
@@ -63,11 +63,7 @@ module.exports = class GithubService {
       head: branch,
       base: 'master'
     })
-    const prNotifier = new PrNotifier({
-      prEventsListener: this.prEventsListener,
-      fakeFlynnApi: this.fakeFlynnApi,
-      branch: pr.head.ref
-    })
+    const prNotifier = this.newPrNotifier(pr.head.ref)
     return {prNotifier, prNumber: pr.number}
   }
 
@@ -108,11 +104,15 @@ module.exports = class GithubService {
     const pr = await this.ghApi.reopenPullRequest({
       number: prNumber
     })
-    const prNotifier = new PrNotifier({
+    const prNotifier = this.newPrNotifier(pr.head.ref)
+    return {prNotifier, prNumber: pr.number}
+  }
+
+  newPrNotifier (branch) {
+    return new PrNotifier({
       prEventsListener: this.prEventsListener,
       fakeFlynnApi: this.fakeFlynnApi,
-      branch: pr.head.ref
+      branch
     })
-    return {prNotifier, prNumber: pr.number}
   }
 }

--- a/features/support/assemblies/github/index.js
+++ b/features/support/assemblies/github/index.js
@@ -55,7 +55,7 @@ module.exports = class GithubAssembly {
     const prApps = new PrApps({
       codeHostingServiceApi: this.codeHostingServiceApi,
       scmProject,
-      workQueue: new WorkQueue({timeout: 10}),
+      workQueue: new WorkQueue({timeout: 200}),
       flynnApiClientFactory: (clusterDomain) => {
         return new FlynnApiClient({
           clusterDomain,

--- a/features/support/assemblies/github/index.js
+++ b/features/support/assemblies/github/index.js
@@ -55,7 +55,7 @@ module.exports = class GithubAssembly {
     const prApps = new PrApps({
       codeHostingServiceApi: this.codeHostingServiceApi,
       scmProject,
-      workQueue: new WorkQueue(),
+      workQueue: new WorkQueue({timeout: 10}),
       flynnApiClientFactory: (clusterDomain) => {
         return new FlynnApiClient({
           clusterDomain,
@@ -159,19 +159,19 @@ class GithubActor extends ApiActorBase {
 
   async openPullRequest ({branch = this.currentBranch} = {}) {
     const {prNotifier, prNumber} = await this.codeHostingService.openPullRequest(branch)
-    this.prNotifier = prNotifier
     this.prNumber = prNumber
-    return prNumber
+    return prNotifier
   }
 
   async reopenPullRequest () {
     const {prNotifier, prNumber} = await this.codeHostingService.reopenPullRequest(this.prNumber)
-    this.prNotifier = prNotifier
     this.prNumber = prNumber
+    return prNotifier
   }
 
   async pushMoreChanges () {
-    this.version = await this.userLocalRepo.pushBranch(this.currentBranch, '<p>This is Pr Apps</p>')
+    await this.userLocalRepo.pushBranch(this.currentBranch, '<p>This is Pr Apps</p>')
+    return this.codeHostingService.newPrNotifier(this.currentBranch)
   }
 
   async mergePullRequest (prNumber = this.prNumber) {

--- a/features/support/assemblies/local/index.js
+++ b/features/support/assemblies/local/index.js
@@ -27,19 +27,6 @@ module.exports = class LocalAssembly {
       getRandomPort(),
       resetDb(db)
     ])
-
-    this.fs = new FsAdapter()
-    const git = new GitAdapter({fs: this.fs})
-
-    this.remoteRepoPath = this.fs.makeTempDir()
-    const remoteRepoSh = new ShellAdapter({cwd: this.remoteRepoPath})
-
-    const remoteUrl = `file:///${this.remoteRepoPath}`
-    const scmProject = new GitProject({
-      remoteUrl,
-      git
-    })
-
     this.clusterDomain = `prs.localtest.me:${port}`
 
     this.fakeFlynnApi = new FakeFlynnApi({
@@ -47,31 +34,53 @@ module.exports = class LocalAssembly {
       clusterDomain: this.clusterDomain
     })
 
-    this.codeHostingServiceApi = new CodeHostingServiceApiMemory()
+    this.remoteRepoPath = new FsAdapter().makeTempDir()
+    const remoteUrl = `file:///${this.remoteRepoPath}`
+    const remoteRepoSh = new ShellAdapter({cwd: this.remoteRepoPath})
+    this.deploymentStatusEvents = []
 
-    const deploymentRepo = new DeploymentRepo(db)
+    const createPrApps = (contextDebug) => {
+      this.codeHostingServiceApi = new CodeHostingServiceApiMemory({
+        deploymentStatusEvents: this.deploymentStatusEvents,
+        contextDebug
+      })
 
-    const prApps = new PrApps({
-      codeHostingServiceApi: this.codeHostingServiceApi,
-      scmProject,
-      workQueue: new WorkQueue({timeout: 200}),
-      flynnApiClientFactory: (clusterDomain) => {
-        return new FlynnApiClient({
-          clusterDomain,
-          authKey: 'flynnApiAuthKey'
-        })
-      },
-      appInfo: {
-        domain: `pr-apps.${this.clusterDomain}`
-      },
-      deploymentRepo,
-      configLoader: new ConfigLoader()
-    })
+      const git = new GitAdapter({
+        fs: new FsAdapter({contextDebug}),
+        contextDebug
+      })
+
+      const scmProject = new GitProject({
+        remoteUrl,
+        git
+      })
+
+      const deploymentRepo = new DeploymentRepo(db)
+
+      return new PrApps({
+        contextDebug,
+        codeHostingServiceApi: this.codeHostingServiceApi,
+        scmProject,
+        workQueue: new WorkQueue({timeout: 200, contextDebug}),
+        flynnApiClientFactory: (clusterDomain) => {
+          return new FlynnApiClient({
+            clusterDomain,
+            authKey: 'flynnApiAuthKey',
+            contextDebug
+          })
+        },
+        appInfo: {
+          domain: `pr-apps.${this.clusterDomain}`
+        },
+        deploymentRepo,
+        configLoader: new ConfigLoader({contextDebug})
+      })
+    }
 
     this.webhookSecret = 'webhook secret'
     const prAppsApp = createPrAppsApp({
       webhookSecret: this.webhookSecret,
-      prApps
+      createPrApps
     })
 
     this.userLocalRepo = new GitRepo({remoteUrl})
@@ -97,7 +106,7 @@ module.exports = class LocalAssembly {
         ? new Promise(resolve => this.prAppsServer.close(resolve))
         : Promise.resolve()
     ])
-    this.fs.rmRf(this.remoteRepoPath)
+    new FsAdapter().rmRf(this.remoteRepoPath)
     await this.userLocalRepo.destroy()
   }
 
@@ -109,7 +118,7 @@ module.exports = class LocalAssembly {
     return new LocalActor({
       userLocalRepo: this.userLocalRepo,
       prAppsClient: this.prAppsClient,
-      codeHostingServiceApi: this.codeHostingServiceApi,
+      deploymentStatusEvents: this.deploymentStatusEvents,
       fakeFlynnApi: this.fakeFlynnApi
     })
   }
@@ -117,14 +126,14 @@ module.exports = class LocalAssembly {
 
 class LocalActor extends ApiActorBase {
   constructor ({
-    codeHostingServiceApi,
+    deploymentStatusEvents,
     userLocalRepo,
     prAppsClient,
     fakeFlynnApi
   }) {
     super({userLocalRepo, fakeFlynnApi, currentBranch: 'Feature1'})
     this.prAppsClient = prAppsClient
-    this.codeHostingServiceApi = codeHostingServiceApi
+    this.deploymentStatusEvents = deploymentStatusEvents
     this.prNumber = 23
   }
 
@@ -141,7 +150,7 @@ class LocalActor extends ApiActorBase {
     await this.prAppsClient.post('/webhook', body)
 
     return new PrNotifier({
-      prEventsListener: this.codeHostingServiceApi,
+      deploymentStatusEvents: this.deploymentStatusEvents,
       branch,
       prNumber,
       fakeFlynnApi: this.fakeFlynnApi
@@ -162,7 +171,7 @@ class LocalActor extends ApiActorBase {
     await this.prAppsClient.post('/webhook', body)
 
     return new PrNotifier({
-      prEventsListener: this.codeHostingServiceApi,
+      deploymentStatusEvents: this.deploymentStatusEvents,
       branch: this.currentBranch,
       prNumber: this.prNumber,
       fakeFlynnApi: this.fakeFlynnApi
@@ -209,7 +218,7 @@ class LocalActor extends ApiActorBase {
     await this.prAppsClient.post('/webhook', body)
 
     return new PrNotifier({
-      prEventsListener: this.codeHostingServiceApi,
+      deploymentStatusEvents: this.deploymentStatusEvents,
       branch: this.currentBranch,
       prNumber: this.prNumber,
       fakeFlynnApi: this.fakeFlynnApi

--- a/features/support/assemblies/local/index.js
+++ b/features/support/assemblies/local/index.js
@@ -54,7 +54,7 @@ module.exports = class LocalAssembly {
     const prApps = new PrApps({
       codeHostingServiceApi: this.codeHostingServiceApi,
       scmProject,
-      workQueue: new WorkQueue({timeout: 10}),
+      workQueue: new WorkQueue({timeout: 200}),
       flynnApiClientFactory: (clusterDomain) => {
         return new FlynnApiClient({
           clusterDomain,

--- a/features/support/assemblies/memory/baseActor.js
+++ b/features/support/assemblies/memory/baseActor.js
@@ -1,6 +1,30 @@
 const {expect} = require('chai')
 
 module.exports = class BaseActor {
+  async shouldSeeDeployStarted (prNotifier) {
+    await prNotifier.waitForDeployStarted()
+  }
+
+  async shouldSeeDeployFinished (prNotifier) {
+    await prNotifier.waitForDeployFinished()
+  }
+
+  async shouldSeeOneDeployAfterAnother (prNotifier) {
+    await prNotifier.assertDeploysAreSequential()
+  }
+
+  async shouldSeeDeploySuccessful (prNotifier) {
+    await prNotifier.waitForDeploySuccessful()
+  }
+
+  async shouldSeeDeployFailed (prNotifier, options) {
+    await prNotifier.waitForDeployFailed(options)
+  }
+
+  getLastDeploymentUrl (prNotifier) {
+    return prNotifier.getDeploymentUrl()
+  }
+
   shouldBeAbleToPushLargeRepos () {
     const initDeploy = this.fakeFlynnApi.firstApp().deploys[0]
     expect(initDeploy.release.processes.slugbuilder.resources.temp_disk.limit).to.eq(1073741824)

--- a/features/support/assemblies/memory/codeHostingServiceApiMemory.js
+++ b/features/support/assemblies/memory/codeHostingServiceApiMemory.js
@@ -1,5 +1,3 @@
-const debug = require('debug')('pr-apps:test:codeHostingServiceApiMemory')
-
 async function simulateAsync () {
   return new Promise((resolve, reject) => {
     setTimeout(resolve)
@@ -7,13 +5,14 @@ async function simulateAsync () {
 }
 
 module.exports = class CodeHostingServiceApiMemory {
-  constructor () {
-    this.deploymentStatusEvents = []
+  constructor ({deploymentStatusEvents, contextDebug = require('debug')}) {
+    this.deploymentStatusEvents = deploymentStatusEvents
+    this.debug = contextDebug('pr-apps:test:codeHostingServiceApiMemory')
   }
 
   async createDeployment (branch) {
     await simulateAsync()
-    debug('Creating deployment for branch %s', branch)
+    this.debug('Creating deployment for branch %s', branch)
     return {
       branch
     }
@@ -27,7 +26,7 @@ module.exports = class CodeHostingServiceApiMemory {
       deployedAppUrl,
       deploymentUrl
     }
-    debug('Updating deployment status %o', update)
+    this.debug('Updating deployment status %o', update)
     this.deploymentStatusEvents.push(update)
   }
 }

--- a/features/support/assemblies/memory/codeHostingServiceApiMemory.js
+++ b/features/support/assemblies/memory/codeHostingServiceApiMemory.js
@@ -1,11 +1,18 @@
 const debug = require('debug')('pr-apps:test:codeHostingServiceApiMemory')
 
+async function simulateAsync () {
+  return new Promise((resolve, reject) => {
+    setTimeout(resolve)
+  })
+}
+
 module.exports = class CodeHostingServiceApiMemory {
   constructor () {
     this.deploymentStatusEvents = []
   }
 
   async createDeployment (branch) {
+    await simulateAsync()
     debug('Creating deployment for branch %s', branch)
     return {
       branch
@@ -13,6 +20,7 @@ module.exports = class CodeHostingServiceApiMemory {
   }
 
   async updateDeploymentStatus (deployment, {status, deployedAppUrl, deploymentUrl}) {
+    await simulateAsync()
     const update = {
       branch: deployment.branch,
       status,

--- a/features/support/assemblies/memory/deploymentRepoMemory.js
+++ b/features/support/assemblies/memory/deploymentRepoMemory.js
@@ -23,6 +23,12 @@ module.exports = class DeploymentRepoMemory {
     this.store[deployment.id] = deployment
   }
 
+  findPending (prNumber) {
+    return Object.values(this.store).find(d => {
+      return d.prNumber === prNumber && d.status === 'pending'
+    })
+  }
+
   deleteAppDeployments (prNumber) {
     Object.entries(this.store).forEach(([id, d]) => {
       if (d.prNumber === prNumber) {

--- a/features/support/assemblies/memory/index.js
+++ b/features/support/assemblies/memory/index.js
@@ -34,7 +34,8 @@ module.exports = class MemoryAssembly {
       fakeFlynnApi: this.fakeFlynnApi
     })
 
-    this.codeHostingServiceApi = new CodeHostingServiceApiMemory()
+    const deploymentStatusEvents = []
+    this.codeHostingServiceApi = new CodeHostingServiceApiMemory({deploymentStatusEvents})
     const configLoader = new ConfigLoaderMemory()
 
     this.clusterDomain = 'prs.example.com'
@@ -59,6 +60,7 @@ module.exports = class MemoryAssembly {
     })
     this.prAppsClient = new PrAppsClientMemory({
       prApps,
+      deploymentStatusEvents,
       fakeFlynnApi: this.fakeFlynnApi
     })
 

--- a/features/support/assemblies/memory/prAppsClientMemory.js
+++ b/features/support/assemblies/memory/prAppsClientMemory.js
@@ -1,9 +1,10 @@
 const PrNotifier = require('./prNotifier')
 
 module.exports = class PrAppsClientMemory {
-  constructor ({prApps, fakeFlynnApi}) {
+  constructor ({prApps, fakeFlynnApi, deploymentStatusEvents}) {
     this.prApps = prApps
     this.fakeFlynnApi = fakeFlynnApi
+    this.deploymentStatusEvents = deploymentStatusEvents
   }
 
   enable () {
@@ -13,7 +14,7 @@ module.exports = class PrAppsClientMemory {
   async redeploy ({branch, prNumber}) {
     await this.prApps.deployUpdate({branch, prNumber})
     return new PrNotifier({
-      prEventsListener: this.prApps.codeHostingServiceApi,
+      deploymentStatusEvents: this.deploymentStatusEvents,
       prNumber,
       fakeFlynnApi: this.fakeFlynnApi,
       branch
@@ -28,7 +29,7 @@ module.exports = class PrAppsClientMemory {
         console.error(e)
       }
       return new PrNotifier({
-        prEventsListener: this.prApps.codeHostingServiceApi,
+        deploymentStatusEvents: this.deploymentStatusEvents,
         prNumber,
         fakeFlynnApi: this.fakeFlynnApi,
         branch
@@ -40,7 +41,7 @@ module.exports = class PrAppsClientMemory {
     if (this.enabled) {
       await this.prApps.deployPullRequest({branch, prNumber})
       return new PrNotifier({
-        prEventsListener: this.prApps.codeHostingServiceApi,
+        deploymentStatusEvents: this.deploymentStatusEvents,
         prNumber,
         fakeFlynnApi: this.fakeFlynnApi,
         branch
@@ -56,7 +57,7 @@ module.exports = class PrAppsClientMemory {
         console.error(e)
       }
       return new PrNotifier({
-        prEventsListener: this.prApps.codeHostingServiceApi,
+        deploymentStatusEvents: this.deploymentStatusEvents,
         prNumber,
         fakeFlynnApi: this.fakeFlynnApi,
         branch

--- a/features/support/assemblies/memory/workQueueSync.js
+++ b/features/support/assemblies/memory/workQueueSync.js
@@ -1,5 +1,0 @@
-module.exports = class WorkQueueSync {
-  async addTask (fn) {
-    return fn()
-  }
-}

--- a/features/viewDeployment.feature
+++ b/features/viewDeployment.feature
@@ -1,5 +1,6 @@
 Feature: View deployment
 
+  @ci
   Scenario: view deployment page of a deployed pr app
     Given Frank opened a pull request
     When Frank follows a deployment link from the last deploy

--- a/lib/configLoader.js
+++ b/lib/configLoader.js
@@ -1,19 +1,22 @@
 const yaml = require('js-yaml')
 const fs = require('fs-extra')
 const path = require('path')
-const debug = require('debug')('pr-apps:configLoader')
 
 module.exports = class ConfigLoader {
+  constructor ({contextDebug = require('debug')} = {}) {
+    this.debug = contextDebug('pr-apps:configLoader')
+  }
+
   load (cwd) {
     const configPath = path.join(cwd, 'pr-app.yaml')
     if (fs.existsSync(configPath)) {
-      debug('Loading config %s', configPath)
+      this.debug('Loading config %s', configPath)
 
       const config = yaml.safeLoad(fs.readFileSync(configPath, 'utf8'))
-      debug('Config loaded %o', config)
+      this.debug('Config loaded %o', config)
       return config
     } else {
-      debug('No config file found at %s', configPath)
+      this.debug('No config file found at %s', configPath)
     }
   }
 }

--- a/lib/contextDebug.js
+++ b/lib/contextDebug.js
@@ -1,0 +1,19 @@
+const crypto = require('crypto')
+const debug = require('debug')
+
+module.exports = class ContextDebug extends Function {
+  constructor () {
+    const contextId = crypto.randomBytes(20).toString('hex')
+
+    function contextDebug (prefix) {
+      const log = debug(prefix)
+
+      return function (...args) {
+        const message = `[${contextId}] ${args.shift()}`
+        log(message, ...args)
+      }
+    }
+    Object.setPrototypeOf(contextDebug, ContextDebug.prototype)
+    return contextDebug
+  }
+}

--- a/lib/deploymentRepo.js
+++ b/lib/deploymentRepo.js
@@ -26,6 +26,18 @@ module.exports = class DeploymentRepo {
     }
   }
 
+  async findPending (prNumber) {
+    const deployment = await this.db.Deployment.findOne({
+      where: {
+        prNumber,
+        status: 'pending'
+      }
+    })
+    if (deployment) {
+      return deployment.toJSON()
+    }
+  }
+
   async save (deployment) {
     const model = this.objectCache[deployment.id]
     await model.update(deployment)

--- a/lib/flynnApiClient.js
+++ b/lib/flynnApiClient.js
@@ -1,11 +1,10 @@
 const httpism = require('httpism')
-const debug = require('debug')('pr-apps:flynnApiClient')
 
 // disable certificate validation because flynn is using self-signed certificate
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
 module.exports = class FlynnApiClient {
-  constructor ({clusterDomain, authKey}) {
+  constructor ({clusterDomain, authKey, contextDebug = require('debug')}) {
     this.authKey = authKey
     this.clusterDomain = clusterDomain
     this.api = httpism.client(`https://controller.${this.clusterDomain}`, {
@@ -14,22 +13,23 @@ module.exports = class FlynnApiClient {
         password: authKey
       }
     })
+    this.debug = contextDebug('pr-apps:flynnApiClient')
   }
 
   async getResources (appId) {
-    debug(`Getting resources for appId %s'`, appId)
+    this.debug(`Getting resources for appId %s'`, appId)
     const resources = await this.api.get(`/apps/${appId}/resources`)
     return resources
   }
 
   async getProvider (providerId) {
-    debug(`Getting provider %s`, providerId)
+    this.debug(`Getting provider %s`, providerId)
     const provider = await this.api.get(`/providers/${providerId}`)
     return provider
   }
 
   async createAppResource ({appId, resourceName}) {
-    debug(`Adding resource %s for appId %s`, resourceName, appId)
+    this.debug(`Adding resource %s for appId %s`, resourceName, appId)
     const newResource = this.api.post(`/providers/${resourceName}/resources`, {
       apps: [appId]
     })
@@ -37,35 +37,35 @@ module.exports = class FlynnApiClient {
   }
 
   async getRelease (appId) {
-    debug(`Getting release for appId %s`, appId)
+    this.debug(`Getting release for appId %s`, appId)
     const release = await this.api.get(`/apps/${appId}/release`)
     return release
   }
 
   async createRelease (release) {
-    debug(`Creating release %j`, release)
+    this.debug(`Creating release %j`, release)
     const newRelease = await this.api.post('/releases', release)
     return newRelease
   }
 
   async deployRelease (appId, releaseId) {
-    debug(`Deploying release %s for appId %s`, releaseId, appId)
+    this.debug(`Deploying release %s for appId %s`, releaseId, appId)
     await this.api.post(`/apps/${appId}/deploy`, {id: releaseId})
   }
 
   async scaleAppProcesses ({appId, releaseId, scaleRequest}) {
-    debug(`Scaling appId %s processes %O`, appId, scaleRequest)
+    this.debug(`Scaling appId %s processes %O`, appId, scaleRequest)
     await this.api.put(`/apps/${appId}/scale/${releaseId}`, scaleRequest)
   }
 
   async getAppRoutes (appId) {
-    debug(`Getting appId %s routes`, appId)
+    this.debug(`Getting appId %s routes`, appId)
     const routes = await this.api.get(`/apps/${appId}/routes`)
     return routes
   }
 
   async createAppRoute (appId, route) {
-    debug('Creating appId %s route %o', appId, route)
+    this.debug('Creating appId %s route %o', appId, route)
     await this.api.post(`/apps/${appId}/routes`, route)
   }
 

--- a/lib/flynnService.js
+++ b/lib/flynnService.js
@@ -1,7 +1,5 @@
-const debug = require('debug')('pr-apps:flynnService')
-
 class FlynnApp {
-  constructor ({id, appName, apiClient}) {
+  constructor ({id, appName, apiClient, debug}) {
     this.id = id
     this.appName = appName
     this.appDomain = `${appName}.${apiClient.clusterDomain}`
@@ -9,10 +7,11 @@ class FlynnApp {
     this.gitUrl = `https://:${apiClient.authKey}@git.${apiClient.clusterDomain}/${appName}.git`
     this.flynnUrl = `https://dashboard.${apiClient.clusterDomain}/apps/${id}`
     this.apiClient = apiClient
+    this.debug = debug
   }
 
   async withConfig ({config = {}}, deployFn) {
-    debug('Applying config %o for appId %s', config, this.id)
+    this.debug('Applying config %o for appId %s', config, this.id)
 
     let resourcesEnv = {}
     if (config.resources) {
@@ -48,9 +47,9 @@ class FlynnApp {
     const newResources = (await Promise.all(
       resources.map(name => {
         if (existingResourceNames.find(r => r === name)) {
-          debug('Skipping resource %s', name)
+          this.debug('Skipping resource %s', name)
         } else {
-          debug('Adding resource %s', name)
+          this.debug('Adding resource %s', name)
           return this.apiClient.createAppResource({appId: this.id, resourceName: name})
         }
       })
@@ -122,7 +121,7 @@ class FlynnApp {
   async _ensureEnv (env) {
     const release = await this._getLastRelease()
 
-    debug('Setting env %o', env)
+    this.debug('Setting env %o', env)
 
     delete release.id
     release.env = Object.assign({}, release.env, env)
@@ -134,12 +133,13 @@ class FlynnApp {
 }
 
 module.exports = class FlynnService {
-  constructor (apiClient) {
+  constructor (apiClient, contextDebug = require('debug')) {
     this.apiClient = apiClient
+    this.debug = contextDebug('pr-apps:flynnService')
   }
 
   async createApp (appName) {
-    debug('Creating pr app %s', appName)
+    this.debug('Creating pr app %s', appName)
 
     const {id} = await this.apiClient.createApp(appName)
 
@@ -166,30 +166,32 @@ module.exports = class FlynnService {
     return new FlynnApp({
       id,
       appName,
-      apiClient: this.apiClient
+      apiClient: this.apiClient,
+      debug: this.debug
     })
   }
 
   async destroyApp (appName) {
-    debug('Destroying pr app %s', appName)
+    this.debug('Destroying pr app %s', appName)
 
     const {id} = await this._findAppByName(appName)
     await this.apiClient.destroyApp(id)
   }
 
   async getApp (appName) {
-    debug('Getting pr app %s', appName)
+    this.debug('Getting pr app %s', appName)
     const {id} = await this._findAppByName(appName)
     return new FlynnApp({
       id,
       appName,
-      apiClient: this.apiClient
+      apiClient: this.apiClient,
+      debug: this.debug
     })
   }
 
   async _findAppByName (appName) {
     const apps = await this.apiClient.apps()
-    debug('Existing apps %o', apps.map(a => a.name))
+    this.debug('Existing apps %o', apps.map(a => a.name))
     return apps.find(a => a.name === appName)
   }
 }

--- a/lib/fsAdapter.js
+++ b/lib/fsAdapter.js
@@ -1,22 +1,25 @@
 const fs = require('fs-extra')
 const os = require('os')
-const debug = require('debug')('pr-apps:fsAdapter')
 
 function getRandomInt (min, max) {
   return Math.floor(Math.random() * (max - min)) + min
 }
 
 module.exports = class FsAdapter {
+  constructor ({contextDebug = require('debug')} = {}) {
+    this.debug = contextDebug('pr-apps:fsAdapter')
+  }
+
   makeTempDir () {
     const path = `${os.tmpdir()}/${getRandomInt(1, 9999999)}`
-    debug('Creating temp dir %s', path)
+    this.debug('Creating temp dir %s', path)
 
     fs.ensureDirSync(path)
     return path
   }
 
   rmRf (path) {
-    debug('Removing path %s', path)
+    this.debug('Removing path %s', path)
     fs.removeSync(path)
   }
 }

--- a/lib/gitAdapter.js
+++ b/lib/gitAdapter.js
@@ -1,19 +1,22 @@
 const ShellAdapter = require('./shellAdapter')
-const debug = require('debug')('pr-apps:gitAdapter')
 
 class Repo {
-  constructor ({fs, sh, path, remoteVersion}) {
+  constructor ({fs, sh, remoteVersion, debug}) {
     this.fs = fs
     this.remoteVersion = remoteVersion
-    this.sh = new ShellAdapter({cwd: path})
-    this.path = path
+    this.sh = sh
+    this.debug = debug
   }
 
   async push (remoteUrl, logCollector) {
-    debug('Pushing HEAD to remote %s master', remoteUrl)
+    this.debug('Pushing HEAD to remote %s master', remoteUrl)
 
     await this.sh(`git remote add flynn ${remoteUrl}`)
     await this.sh('git -c http.sslVerify=false push -f flynn HEAD:refs/heads/master', {logCollector})
+  }
+
+  get path () {
+    return this.sh.cwd
   }
 
   remove () {
@@ -22,15 +25,17 @@ class Repo {
 }
 
 module.exports = class GitAdapter {
-  constructor ({fs}) {
+  constructor ({fs, contextDebug = require('debug')}) {
     this.fs = fs
+    this.contextDebug = contextDebug
+    this.debug = contextDebug('pr-apps:gitAdapter')
   }
 
   async makePushableClone ({repoUrl, branch}) {
-    debug('Cloning %s#%s', repoUrl, branch)
+    this.debug('Cloning %s#%s', repoUrl, branch)
 
     const tmpDir = this.fs.makeTempDir()
-    const sh = new ShellAdapter({cwd: tmpDir})
+    const sh = new ShellAdapter({cwd: tmpDir, contextDebug: this.contextDebug})
 
     await sh(`git clone --depth 1 --branch ${branch} ${repoUrl} ${tmpDir}`)
     const remoteVersion = await sh('git rev-parse HEAD')
@@ -42,9 +47,10 @@ module.exports = class GitAdapter {
     await sh('git commit -m "pr deploy" -q')
 
     return new Repo({
-      path: tmpDir,
+      sh,
       remoteVersion,
-      fs: this.fs
+      fs: this.fs,
+      debug: this.debug
     })
   }
 }

--- a/lib/githubApiAdapter.js
+++ b/lib/githubApiAdapter.js
@@ -1,11 +1,11 @@
 const GitHubApi = require('@octokit/rest')
-const debug = require('debug')('pr-apps:github')
 const GithubUrl = require('./githubUrl')
 
 module.exports = class GithubApiAdapter {
-  constructor ({token, repo}) {
+  constructor ({token, repo, contextDebug}) {
     ({owner: this.owner, repo: this.repo} = new GithubUrl({repoUrl: repo, token}))
 
+    this.debug = contextDebug('pr-apps:github')
     this.ghApi = new GitHubApi()
     this.ghApi.authenticate({
       type: 'token',
@@ -19,10 +19,10 @@ module.exports = class GithubApiAdapter {
 
   async createDeployment (branch) {
     if (this.disabled) {
-      return debug('createDeployment disabled')
+      return this.debug('createDeployment disabled')
     }
 
-    debug('Creating deployment for branch %s', branch)
+    this.debug('Creating deployment for branch %s', branch)
 
     const {data: deployment} = await this.ghApi.repos.createDeployment({
       owner: this.owner,
@@ -38,10 +38,10 @@ module.exports = class GithubApiAdapter {
 
   async updateDeploymentStatus (deployStatus, {status, deployedAppUrl, deploymentUrl}) {
     if (this.disabled) {
-      return debug('updateDeploymentStatus disabled')
+      this.debug('updateDeploymentStatus disabled')
     }
 
-    debug('Updating deployment status to %s, deployedAppUrl: %s, deploymentUrl: %s', status, deployedAppUrl, deploymentUrl)
+    this.debug('Updating deployment status to %s, deployedAppUrl: %s, deploymentUrl: %s', status, deployedAppUrl, deploymentUrl)
 
     await this.ghApi.repos.createDeploymentStatus({
       owner: this.owner,

--- a/lib/prApps.js
+++ b/lib/prApps.js
@@ -71,6 +71,13 @@ module.exports = class PrApps {
       ? await this.flynnService.createApp(appName)
       : await this.flynnService.getApp(appName)
 
+    const pendingDeployment = await this.deploymentRepo.findPending(prNumber)
+
+    if (pendingDeployment) {
+      this.workQueue.addTask(() => this._deploy(...arguments), {delayed: true})
+      return
+    }
+
     const deployment = await this.deploymentRepo.create({
       prNumber,
       branch,
@@ -78,12 +85,17 @@ module.exports = class PrApps {
       status: 'pending'
     })
 
-    await this.workQueue.addTask(async () => {
-      const codeHostingServiceDeployment = await this.codeHostingServiceApi.createDeployment(branch)
+    this.workQueue.addTask(this._deploymentTask({deployment, flynnApp}))
+    return deployment
+  }
+
+  _deploymentTask ({deployment, flynnApp}) {
+    return async () => {
+      const codeHostingServiceDeployment = await this.codeHostingServiceApi.createDeployment(deployment.branch)
       const deploymentUrl = `https://${this.prAppsDomain}/deployments/${deployment.id}`
 
       try {
-        await this.scmProject.clone(branch, async (localProject) => {
+        await this.scmProject.clone(deployment.branch, async (localProject) => {
           deployment.version = localProject.remoteVersion
           await this.deploymentRepo.save(deployment)
 
@@ -115,16 +127,13 @@ module.exports = class PrApps {
         deployment.status = 'failure'
         throw e
       } finally {
-        await Promise.all([
-          this.deploymentRepo.save(deployment),
-          this.codeHostingServiceApi.updateDeploymentStatus(
-            codeHostingServiceDeployment,
-            Object.assign({deploymentUrl}, deployment)
-          )
-        ])
+        await this.deploymentRepo.save(deployment)
+        await this.codeHostingServiceApi.updateDeploymentStatus(
+          codeHostingServiceDeployment,
+          Object.assign({deploymentUrl}, deployment)
+        )
       }
-    })
-    return deployment
+    }
   }
 
   _loadConfig (path, flynnApp) {

--- a/lib/prApps.js
+++ b/lib/prApps.js
@@ -31,7 +31,8 @@ module.exports = class PrApps {
     workQueue,
     appInfo,
     deploymentRepo,
-    configLoader
+    configLoader,
+    contextDebug
   }) {
     this.scmProject = scmProject
     this.codeHostingServiceApi = codeHostingServiceApi
@@ -41,7 +42,7 @@ module.exports = class PrApps {
 
     const {clusterDomain, prAppsDomain} = loadFlynnInfo(appInfo)
     const flynnApiClient = flynnApiClientFactory(clusterDomain)
-    this.flynnService = new FlynnService(flynnApiClient)
+    this.flynnService = new FlynnService(flynnApiClient, contextDebug)
     this.prAppsDomain = prAppsDomain
   }
 

--- a/lib/shellAdapter.js
+++ b/lib/shellAdapter.js
@@ -1,7 +1,4 @@
 const {spawn} = require('child_process')
-const debug = require('debug')('pr-apps:shell')
-const debugStdout = require('debug')('pr-apps:shell:stdout')
-const debugStderr = require('debug')('pr-apps:shell:stderr')
 
 const nullCollector = {
   write () {},
@@ -9,7 +6,9 @@ const nullCollector = {
 }
 
 module.exports = class ShellAdapter extends Function {
-  constructor ({cwd}) {
+  constructor ({cwd, contextDebug = require('debug')}) {
+    const debug = contextDebug('pr-apps:shell')
+
     async function shell (cmd, {logCollector = nullCollector} = {}) {
       debug('Running `%s`', cmd)
       return new Promise((resolve, reject) => {
@@ -19,12 +18,12 @@ module.exports = class ShellAdapter extends Function {
         sp.stdout.on('data', (data) => {
           result += data
           logCollector.write(data)
-          debugStdout(data.toString())
+          debug('stdout:', data.toString())
         })
         sp.stderr.on('data', (data) => {
           result += data
           logCollector.write(data)
-          debugStderr(data.toString())
+          debug('stderr:', data.toString())
         })
         sp.on('close', (code) => {
           logCollector.end()
@@ -41,6 +40,7 @@ module.exports = class ShellAdapter extends Function {
       })
     }
     Object.setPrototypeOf(shell, ShellAdapter.prototype)
+    shell.cwd = cwd
     return shell
   }
 }

--- a/lib/workQueue.js
+++ b/lib/workQueue.js
@@ -1,17 +1,19 @@
+const debug = require('debug')('pr-apps:workQueue')
+
+let idSeq = 111
+
 module.exports = class WorkQueue {
-  constructor () {
-    this._queue = []
-    setInterval(() => this._process(), 100)
+  constructor ({timeout = 60000} = {}) {
+    this.timeout = timeout
   }
 
-  async addTask (fn) {
-    this._queue.push(fn)
-  }
-
-  async _process () {
-    const taskFn = this._queue.shift()
-    if (taskFn) {
-      await taskFn()
-    }
+  addTask (fn, {delayed} = {}) {
+    const id = idSeq++
+    setTimeout(() => {
+      debug(`Processing${delayed ? ' delayed' : ''} task #${id}`)
+      fn()
+        .then(() => debug(`Completed task #${id}`))
+        .catch(e => console.error(e))
+    }, delayed ? this.timeout : 0)
   }
 }

--- a/lib/workQueue.js
+++ b/lib/workQueue.js
@@ -1,18 +1,17 @@
-const debug = require('debug')('pr-apps:workQueue')
-
 let idSeq = 111
 
 module.exports = class WorkQueue {
-  constructor ({timeout = 60000} = {}) {
+  constructor ({timeout = 60000, contextDebug = require('debug')} = {}) {
     this.timeout = timeout
+    this.debug = contextDebug('pr-apps:workQueue')
   }
 
   addTask (fn, {delayed} = {}) {
     const id = idSeq++
     setTimeout(() => {
-      debug(`Processing${delayed ? ' delayed' : ''} task #${id}`)
+      this.debug(`Processing${delayed ? ' delayed' : ''} task #${id}`)
       fn()
-        .then(() => debug(`Completed task #${id}`))
+        .then(() => this.debug(`Completed${delayed ? ' delayed' : ''} task #${id}`))
         .catch(e => console.error(e))
     }, delayed ? this.timeout : 0)
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "DEBUG=pr-apps* nodemon --inspect index.js",
+    "test": "./test-memory && ./test-local && ./test-real",
     "heroku-postbuild": "./scripts/postbuild"
   },
   "dependencies": {

--- a/test
+++ b/test
@@ -6,4 +6,4 @@ export COVERAGE=1
 standard $(git ls-files | grep -e '.js$')
 ./test-memory
 ./test-local
-./test-real
+./test-real --tags @ci

--- a/test-local
+++ b/test-local
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 . ./scripts/test_commands.sh
-RETRY_TIMEOUT=2000 CUCUMBER_ASSEMBLY=local cucumber_normal "$@"
+CUCUMBER_ASSEMBLY=local RETRY_TIMEOUT=${RETRY_TIMEOUT:-2000} cucumber_normal "$@"

--- a/test-memory
+++ b/test-memory
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 . ./scripts/test_commands.sh
-cucumber_normal "$@"
+RETRY_TIMEOUT=${RETRY_TIMEOUT:-1000} cucumber_normal "$@"

--- a/test-real
+++ b/test-real
@@ -2,6 +2,5 @@
 
 . ./scripts/test_commands.sh
 export CUCUMBER_ASSEMBLY=github
-export RETRY_TIMEOUT=20000
 
 cucumber_normal "$@"


### PR DESCRIPTION
Sometimes a series of commits back to back confuses the hell out of pr-apps because it's trying to deploy them all at the same time. This pr will make sure new deploy (of the same pr) only starts once there are no deploys in progress.